### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+    PIP_DISABLE_PIP_VERSION_CHECK: 1
+    PIP_NO_PYTHON_VERSION_WARNING: 1
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          all_but_latest: true
+
+      - name: Check out project
+        uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Get pip cache info
+        id: pip-cache
+        run: |
+          echo "dir=$(python -m pip cache dir)" >> $GITHUB_OUTPUT
+          echo "py=$(python -c'import sys; print("%d.%d" % sys.version_info[:2])')" >> $GITHUB_OUTPUT
+
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-py${{ steps.pip-cache.outputs.py }}-${{ hashFiles('setup.cfg') }}
+          restore-keys: ${{ runner.os }}-pip-py${{ steps.pip-cache.outputs.py }}-
+
+      - name: Install dependencies
+        run: python -m pip install -e .
+
+      - name: List installed packages
+        run: python -m pip list
+
+      - name: Run tests
+        run: python -m unittest discover
+

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 5.1 - Unreleased
 ----------------
 
+- Do not require setup.py or setup.cfg if pyproject.toml exists.
+  [stefan]
 
 5.0 - 2022-02-26
 ----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 5.1 - Unreleased
 ----------------
 
+- Support Python 2.7 - 3.11.
+  [stefan]
+
 - Do not require setup.py or setup.cfg if pyproject.toml exists.
   [stefan]
 

--- a/jarn/mkrelease/colors.py
+++ b/jarn/mkrelease/colors.py
@@ -4,7 +4,11 @@ import blessed
 
 
 def color(func):
-    functools.wraps(func)
+    assignments = functools.WRAPPER_ASSIGNMENTS
+    if not hasattr(func, '__name__'):
+        assignments = [x for x in assignments if x != '__name__']
+
+    @functools.wraps(func, assignments)
     def wrapper(string):
         if os.environ.get('JARN_NO_COLOR') == '1':
             return string

--- a/jarn/mkrelease/setuptools.py
+++ b/jarn/mkrelease/setuptools.py
@@ -52,11 +52,14 @@ class Setuptools(object):
         return env
 
     def is_valid_package(self, dir):
-        return isfile(join(dir, 'setup.py')) or isfile(join(dir, 'setup.cfg'))
+        return (isfile(join(dir, 'setup.py')) or
+                isfile(join(dir, 'setup.cfg')) or
+                isfile(join(dir, 'pyproject.toml')))
 
     def check_valid_package(self, dir):
         if not self.is_valid_package(dir):
-            err_exit('mkrelease: No setup.py in %(dir)s' % locals())
+            err_exit('mkrelease: No setup in %(dir)s\n'
+                     'Expected setup.py and/or setup.cfg and/or pyproject.toml' % locals())
 
     @chdir
     def get_package_info(self, dir, develop=False):

--- a/jarn/mkrelease/setuptools.py
+++ b/jarn/mkrelease/setuptools.py
@@ -23,6 +23,11 @@ from .colors import bold
 OK_RESPONSE = 'Server response (200): OK'
 GONE_RESPONSE = 'Server response (410):'
 
+FILTERWARNINGS = ('-W "ignore:setup.py install is deprecated" '
+                  '-W "ignore:easy_install command is deprecated" '
+                  '-W "ignore:Support for \`[tool.setuptools]\` in \`pyproject.toml\`" '
+                  '-W "ignore:The namespace_packages parameter is deprecated"')
+
 
 class Setuptools(object):
     """Interface to setuptools."""
@@ -202,9 +207,9 @@ class Setuptools(object):
         setup.py.
         """
         python = self.python
-        run_setup = 'from jarn.mkrelease import setup; setup.run(%(args)r, ff=%(ff)r)'
-        filterwarnings = '-W "ignore:setup.py install is deprecated"'
+        filterwarnings = FILTERWARNINGS
 
+        run_setup = 'from jarn.mkrelease import setup; setup.run(%(args)r, ff=%(ff)r)'
         setup_py = '-c"%s"' % (run_setup % locals())
 
         rc, lines = self.process.popen(

--- a/jarn/mkrelease/testing.py
+++ b/jarn/mkrelease/testing.py
@@ -342,6 +342,8 @@ class setenv(object):
     def __exit__(self, *ignored):
         if self._saved is not None:
             os.environ[self._name] = self._saved
+        else:
+            del os.environ[self._name]
 
 
 class delenv(object):

--- a/tests/test_mkrelease.py
+++ b/tests/test_mkrelease.py
@@ -9,6 +9,7 @@ from jarn.mkrelease.mkrelease import main
 
 from jarn.mkrelease.testing import GitSetup
 from jarn.mkrelease.testing import quiet
+from jarn.mkrelease.testing import setenv
 
 PY = sys.version_info[0]
 
@@ -16,7 +17,8 @@ PY = sys.version_info[0]
 class FunctionalTests(GitSetup):
 
     def mkrelease(self, args):
-        return main(args)
+        with setenv('JARN_RUN', '1'):
+            return main(args)
 
     @quiet
     def test_gztar_release(self):

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # "pip install tox" and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py36, py37, py38, py39, py310
+envlist = py27, py36, py37, py38, py39, py310, py311
 
 [testenv]
 passenv =


### PR DESCRIPTION
- Fix wrapping in color decorator.
- Filter more deprecation warnings.
- Do not require setup.py or setup.cfg if pyproject.toml exists.
- Update tox.ini.
- Clean up JARN_RUN environment variable after functional tests.
- Add CI workflow.
